### PR TITLE
[WIP][Tensor] Fix memory access error in getData

### DIFF
--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1613,7 +1613,7 @@ public:
       return nullptr;
 
     data->validate();
-    return (T *)((data->getAddr<T>()) + offset);
+    return (T *)((data->getAddr<T>()) + offset * sizeof(T));
   }
 
   /**
@@ -1625,7 +1625,7 @@ public:
       return nullptr;
 
     data->validate();
-    return (T *)(data->getAddr<T>() + offset);
+    return (T *)(data->getAddr<T>() + offset * sizeof(T));
   }
 
   /**
@@ -1639,7 +1639,7 @@ public:
     size_t index = idx * sizeof(T);
 
     data->validate();
-    return (T *)(data->getAddr<T>() + offset + index);
+    return (T *)(data->getAddr<T>() + (offset + index) * sizeof(T));
   }
 
   void setDataType(Tdatatype d_type) { dim.setDataType(d_type); }

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -441,11 +441,11 @@ TEST(TensorPool, validate_memory) {
  * @param t2 tensor2
  */
 static void testNoOverlap(nntrainer::Tensor *t1, nntrainer::Tensor *t2) {
-  char *t1_start = t1->getData<char>();
-  char *t1_end = t1_start + t1->bytes();
+  float *t1_start = t1->getData<float>();
+  float *t1_end = t1_start + t1->bytes();
 
-  char *t2_start = t2->getData<char>();
-  char *t2_end = t2_start + t2->bytes();
+  float *t2_start = t2->getData<float>();
+  float *t2_end = t2_start + t2->bytes();
 
   EXPECT_NE(t1_start, nullptr);
   EXPECT_NE(t2_start, nullptr);
@@ -460,11 +460,11 @@ static void testNoOverlap(nntrainer::Tensor *t1, nntrainer::Tensor *t2) {
  * @param t2 t2 tensor 2
  */
 static void testSubset(nntrainer::Tensor *t1, nntrainer::Tensor *t2) {
-  char *t1_start = t1->getData<char>();
-  char *t1_end = t1_start + t1->bytes();
-
-  char *t2_start = t2->getData<char>();
-  char *t2_end = t2_start + t2->bytes();
+  float *t1_start = t1->getData<float>();
+  float *t1_end = t1_start + t1->bytes();
+  
+  float *t2_start = t2->getData<float>();
+  float *t2_end = t2_start + t2->bytes();
 
   EXPECT_NE(t1_start, nullptr);
   EXPECT_NE(t2_start, nullptr);


### PR DESCRIPTION
- Pointer arithmetic is not valid when data in MemoryData is a void pointer
- Offset needs to be multiply with size of Tensor DataType in order to access exact memory address
- This PR would enable to pass of all `unittest_nntrainer_tensor_pool` test cases
- This fix could be related to 6d5cd70d264e530e63c4b96f8806c9cd4f8bd7eb
