### PR TITLE
[Bug] Fix generating NaN values in tensor

### DIFF
--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -95,7 +95,7 @@ void MemoryPool::allocate() {
   if (mem_pool != nullptr)
     throw std::runtime_error("Memory pool is already allocated");
 
-  mem_pool = malloc(pool_size);
+  mem_pool = calloc(pool_size, 1);
   if (mem_pool == nullptr)
     throw std::runtime_error(
       "Failed to allocate memory: " + std::to_string(pool_size) + "bytes");


### PR DESCRIPTION

## Commits to be reviewed in this PR

<details><summary>   [Bug] Fix generating nan values in tensor </summary><br />

This PR resolves failed test case issues from `unittest_nntrainer_models` and `unittest_models`.
- Gradient tensor values are inconsistently set to NaN
- NaN values caused incorrect backwarding in Neural Net
- Replacing malloc with calloc prevents memory allocation with value set to NaN

Signed-off-by:dhyeon.jeong <dhyeon.jeong@samsung.com>
</details>
