### PR TITLE
[Bug] Fix redundant call to sgemv fp16 function

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -68,22 +68,24 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
 
   if (TransA == CblasTrans) {
 #ifdef USE__FP16
-    if (incX == 1 && incY == 1 && (N % 16 == 0 || N % 8 == 0 || N % 4 == 0)) {
+    if (incX == 1 && incY == 1 && (N % 16 == 0 || N % 8 == 0)) {
       nntrainer::neon::sgemv_transpose_neon_fp16(A, X, Y, M, N, alpha, beta);
     } else {
-      sgemv_loop(i, j, N, M);
+      sgemv_loop_fp16(i, j, N, M);
     }
-#endif
+#else
     sgemv_loop_fp16(i, j, N, M);
+#endif
   } else {
 #ifdef USE__FP16
-    if (incX == 1 && incY == 1 && (N % 16 == 0 || N % 8 == 0 || N % 4 == 0)) {
+    if (incX == 1 && incY == 1 && (N % 16 == 0 || N % 8 == 0)) {
       nntrainer::neon::sgemv_neon_fp16(A, X, Y, M, N, alpha, beta);
     } else {
-      sgemv_loop(j, i, M, N);
+      sgemv_loop_fp16(j, i, M, N);
     }
-#endif
+#else
     sgemv_loop_fp16(j, i, M, N);
+#endif
   }
 }
 


### PR DESCRIPTION
Added conditions for handling function call based on USE__FP16 identifier.

## Commits to be reviewed in this PR

<details><summary>   Fix redundant call to sgemv fp16 function    </summary><br />

- Wrapped `sgemv_loop_fp16` inside condition to prevent redundant call if platform is android.
- Modified condition for NEON call to avoid failure for `N = 4` (column size).
- All `sgemv` related unit tests passed.

Signed-off-by: s-debadri <s.debadri@samsung.com>
</details>
