### PR TITLE
Fix meson build options to support ARM properly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,8 @@ if get_option('enable-fp16')
    if get_option('platform') == 'android'
      add_project_arguments('-mfp16-format=ieee', language: ['c', 'cpp'])
      extra_defines += '-DUSE__FP16=1'
+   elif arch == 'aarch64' or arch =='arm'
+     extra_defines += '-DUSE__FP16=1'
    else
      has_avx512fp16 = cc.has_argument('-mavx512fp16')
      if (has_avx512fp16)

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -17,7 +17,6 @@ tensor_sources = [
   'optimized_v2_planner.cpp',
   'optimized_v3_planner.cpp',
   'task_executor.cpp',
-  'blas_neon.cpp',
 ]
 
 tensor_headers = [
@@ -25,6 +24,12 @@ tensor_headers = [
   'tensor.h',
   'tensor_wrap_specs.h'
 ]
+
+arch = target_machine.cpu_family()
+
+if get_option('platform') == 'android' or arch == 'aarch64' or arch =='arm'
+  tensor_sources += 'blas_neon.cpp'
+endif
 
 foreach s : tensor_sources
   nntrainer_sources += meson.current_source_dir() / s


### PR DESCRIPTION
## Commits to be reviewed in this PR

<details><summary>  Fix meson build options to support ARM properly </summary><br />

- Check for non-android ARM machines
- Use blas_neon.cpp only for android


Signed-off-by:dhyeon.jeong <dhyeon.jeong@samsung.com>
</details>
