### PR TITLE
[Bug] Change the string format of the tensor datatype

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -50,7 +50,7 @@ public:
     optimize_memory(true),
     exec_mode(ExecutionMode::TRAIN),
     tensor_format("NCHW"),
-    tensor_dtype(split("FP32_FP32", std::regex("\\_"))) {}
+    tensor_dtype(split("FP32-FP32", std::regex("\\-"))) {}
 
   /**
    * @brief     Constructor of NeuralNetwork Graph Class
@@ -60,7 +60,7 @@ public:
   NetworkGraph(bool enable_swap, const std::string &swap_path = "",
                unsigned int lookahead = 0,
                const std::string &tensor_format_ = "NCHW",
-               const std::string &tensor_dtype_ = "FP32_FP32") :
+               const std::string &tensor_dtype_ = "FP32-FP32") :
     tensor_manager(std::make_shared<Manager>(enable_swap, swap_path, lookahead,
                                              tensor_format_, tensor_dtype_)),
     graph(),
@@ -72,7 +72,7 @@ public:
     optimize_memory(true),
     exec_mode(ExecutionMode::TRAIN),
     tensor_format(tensor_format_),
-    tensor_dtype(split(tensor_dtype_, std::regex("\\_"))) {}
+    tensor_dtype(split(tensor_dtype_, std::regex("\\-"))) {}
 
   /**
    * @brief   Destructor of the NeuralNetwork Graph class

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -187,8 +187,8 @@ struct ModelTensorDataTypeInfo {
   static constexpr std::initializer_list<Enum> EnumList = {
     Enum::W16A16, Enum::W16A32, Enum::W32A16, Enum::W32A32};
 
-  static constexpr const char *EnumStr[] = {"FP16_FP16", "FP16_FP32",
-                                            "FP32_FP16", "FP32_FP32"};
+  static constexpr const char *EnumStr[] = {"FP16-FP16", "FP16-FP32",
+                                            "FP32-FP16", "FP32-FP32"};
 };
 
 /**

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -134,20 +134,20 @@ public:
     enable_optimizations(true),
     swap_lookahead(0),
     tensor_format("NCHW"),
-    tensor_dtype(split("FP32_FP32", std::regex("\\_"))) {}
+    tensor_dtype(split("FP32-FP32", std::regex("\\-"))) {}
 
   /**
    * @brief     Constructor of Manager
    */
   Manager(bool enable_swap, const std::string &swap_path = "",
           unsigned int lookahead = 0, const std::string tensor_format_ = "NCHW",
-          const std::string tensor_dtype_ = "FP32_FP32") :
+          const std::string tensor_dtype_ = "FP32-FP32") :
     weight_pool(enable_swap, swap_path, "weight_pool"),
     tensor_pool(enable_swap, swap_path, "tensor_pool"),
     enable_optimizations(true),
     swap_lookahead(lookahead),
     tensor_format(tensor_format_),
-    tensor_dtype(split(tensor_dtype_, std::regex("\\_"))) {}
+    tensor_dtype(split(tensor_dtype_, std::regex("\\-"))) {}
 
   /**
    * @brief Construct a new Manager object (deleted)


### PR DESCRIPTION
## Commits to be reviewed in this PR

<details><summary>   [Bug] Change the string format of the tensor datatype </summary><br />

- Substitute underscore to hyphen in defining tenser datatype.
- The _ (underscore) character used in std::regex is treated as a quantifier in LLVM.
- This PR resolves issues in failed run tests on Android.

Signed-off-by:dhyeon.jeong <dhyeon.jeong@samsung.com>
</details>
