### PR TITLE
Tensor] Read quantized tensor from binary file

### DIFF
--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -159,8 +159,28 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
   // size is 1
   Tensor input_step = input_.getSharedDataTensor(input_step_dim, 0, true);
   Tensor hidden_step = hidden_.getSharedDataTensor(hidden_step_dim, 0, true);
+  Tensor weight_;
 
-  input_step.dot(weight, hidden_step, false, false);
+  if (weight.getDataType() == nntrainer::Tdatatype::QINT4 ||
+      weight.getDataType() == nntrainer::Tdatatype::QINT8) {
+    Tdatatype dtype = input_step.getDataType();
+
+    unsigned int axis =
+      context.getWeightObject(weight_idx[FCParams::weight]).getOutputAxis();
+
+    if (dtype == nntrainer::Tdatatype::FP32)
+      weight_ = weight.dequantize<float>(axis);
+    else if (dtype == nntrainer::Tdatatype::FP16)
+#ifdef ENABLE_FP16
+      weight_ = weight.dequantize<_FP16>(axis);
+#else
+      ml_loge("%s", "Error: enable-fp16 is not enabled");
+#endif
+  } else {
+    weight_ = weight;
+  }
+
+  input_step.dot(weight_, hidden_step, false, false);
 
   if (auto &disable_bias = std::get<props::DisableBias>(*layer_impl_props);
       disable_bias.empty() || disable_bias.get() == false) {

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -3154,7 +3154,7 @@ void Tensor::save(std::ostream &file) {
   putData();
 }
 
-void Tensor::read(std::ifstream &file) {
+void Tensor::read(std::ifstream &file, Tdatatype s_type) {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot read.";
 
@@ -3163,6 +3163,54 @@ void Tensor::read(std::ifstream &file) {
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
     << "read size: " << bytes()
     << " is too big. It cannot be represented by std::streamsize";
+
+  if (getDataType() == Tdatatype::QINT4 || getDataType() == Tdatatype::QINT8) {
+    uint8_t axis, zp;
+    unsigned int len;
+
+    file.read((char *)&axis, sizeof(uint8_t));
+
+    if (axis == 0)
+      len = batch();
+    else if (axis == 1) {
+      len = channel();
+    } else if (axis == 2) {
+      len = height();
+    } else if (axis == 3) {
+      len = width();
+    }
+
+    // read scale factors
+    for (unsigned int i = 0; i < len; ++i) {
+      if (s_type == Tdatatype::FP32) {
+        float scale;
+        file.read((char *)&scale, sizeof(float));
+        scale_factors.push_back(scale);
+      } else if (s_type == Tdatatype::FP16) {
+#ifdef ENABLE_FP16
+        _FP16 scale;
+        file.read((char *)&scale, sizeof(_FP16));
+        scale_factors.push_back((float)scale);
+#else
+        throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+      }
+    }
+
+    // read zero points and parse if needed
+    if (getDataType() == Tdatatype::QINT4) {
+      for (unsigned int i = 0; i < (len + 1) / 2; ++i) {
+        file.read((char *)&zp, sizeof(uint8_t));
+        zero_points.push_back(decode_qint(zp, true));
+        zero_points.push_back(decode_qint(zp, false));
+      }
+    } else if (getDataType() == Tdatatype::QINT8) {
+      for (unsigned int i = 0; i < len; ++i) {
+        file.read((char *)&zp, sizeof(uint8_t));
+        zero_points.push_back(zp);
+      }
+    }
+  }
 
   checkedRead(file, (char *)getData(), sz, "[Tensor::read] operation failed");
   putData();
@@ -3595,34 +3643,9 @@ uint8_t Tensor::decode_qint(uint8_t val, bool isHigh) const {
   return val;
 }
 
-void Tensor::setOutputAxis(int axis) {
-  if (axis < 0 || axis > 3) {
-    throw std::invalid_argument("Error: invalid parameter");
-  }
-  output_axis = axis;
-}
-
-int Tensor::getOutputAxis() const { return output_axis; }
-
 void Tensor::setScaleFactors(std::vector<float> scales) {
   if (scales.empty()) {
     throw std::invalid_argument("Error: invalid parameter");
-  }
-
-  if (output_axis == 0 && scales.size() != batch()) {
-    throw std::invalid_argument("Error: scale_factors.size() != batch() ");
-  }
-
-  if (output_axis == 1 && scales.size() != channel()) {
-    throw std::invalid_argument("Error: scale_factors.size() != channel() ");
-  }
-
-  if (output_axis == 2 && scales.size() != height()) {
-    throw std::invalid_argument("Error: scale_factors.size() != height() ");
-  }
-
-  if (output_axis == 3 && scales.size() != width()) {
-    throw std::invalid_argument("Error: scale_factors.size() != width() ");
   }
 
   scale_factors = scales;
@@ -3633,22 +3656,6 @@ std::vector<float> Tensor::getScaleFactors() const { return scale_factors; }
 void Tensor::setZeroPoints(std::vector<uint8_t> zp) {
   if (zp.empty()) {
     throw std::invalid_argument("Error: invalid parameter");
-  }
-
-  if (output_axis == 0 && zp.size() != batch()) {
-    throw std::invalid_argument("Error: zero_points.size() != batch() ");
-  }
-
-  if (output_axis == 1 && zp.size() != channel()) {
-    throw std::invalid_argument("Error: zero_points.size() != channel() ");
-  }
-
-  if (output_axis == 2 && zp.size() != height()) {
-    throw std::invalid_argument("Error: zero_points.size() != height() ");
-  }
-
-  if (output_axis == 3 && zp.size() != width()) {
-    throw std::invalid_argument("Error: zero_points.size() != width() ");
   }
 
   zero_points = zp;

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1417,8 +1417,7 @@ public:
    */
   size_t bytes() const {
     if (getDataType() == Tdatatype::QINT4) {
-      return (dim.batch() + 1) * (dim.channel() + 1) * (dim.height() + 1) *
-             (dim.width() + 1) / 16 * dim.getDataTypeSize();
+      return (size() * dim.getDataTypeSize() + 1) / 2;
     }
     return size() * dim.getDataTypeSize();
   }
@@ -1672,8 +1671,9 @@ public:
   /**
    * @brief     Read the Tensor from file
    * @param[in] file input file stream
+   * @param[in] s_type scale factor data type
    */
-  void read(std::ifstream &file);
+  void read(std::ifstream &file, Tdatatype s_type = Tdatatype::FP32);
 
   /**
    * @brief     return argument index which value is max by batch
@@ -1954,19 +1954,6 @@ public:
   Tdatatype getDataType() const { return dim.getDataType(); }
 
   /**
-   * @brief Set output axis of the tensor
-   * @param[in] axis output axis (0: batch, 1: channel, 2: height, 3: width)
-   */
-  void setOutputAxis(int axis);
-
-  /**
-   * @brief Get output axis of the tensor
-   *
-   * @return output axis of the tensor
-   */
-  int getOutputAxis() const;
-
-  /**
    * @brief     Set scale factors of the tensor
    * @param[in] scales scale factors
    */
@@ -1996,14 +1983,14 @@ public:
    * @brief     Dequantize Tensor
    * @retval    Dequantized Tensor
    */
-  template <typename T = float> Tensor dequantize() const {
+  template <typename T = float> Tensor dequantize(unsigned int axis) const {
     Tdatatype dtype =
       (typeid(T) == typeid(float)) ? Tdatatype::FP32 : Tdatatype::FP16;
 
     Tensor t =
       Tensor(batch(), channel(), height(), width(), getFormat(), dtype);
 
-    return dequantize<T>(t);
+    return dequantize<T>(t, axis);
   }
 
   /**
@@ -2012,7 +1999,7 @@ public:
    * @retval     Dequantized Tensor
    */
   template <typename T>
-  Tensor &dequantize(Tensor &output) const {
+  Tensor &dequantize(Tensor &output, unsigned int axis) const {
     if (getDataType() == Tdatatype::FP32 || getDataType() == Tdatatype::FP16) {
       throw std::invalid_argument("Error: Tensor cannot be dequantized");
     }
@@ -2033,18 +2020,42 @@ public:
       throw std::invalid_argument("Error: No scale factors");
     }
 
+    if (zero_points.empty()) {
+      throw std::invalid_argument("Error: No zero points");
+    }
+
+    if (axis == 0 && scale_factors.size() != batch() &&
+        zero_points.size() != batch()) {
+      throw std::invalid_argument("Error: output axis do not match ");
+    }
+
+    if (axis == 1 && scale_factors.size() != channel() &&
+        zero_points.size() != channel()) {
+      throw std::invalid_argument("Error: output axis do not match ");
+    }
+
+    if (axis == 2 && scale_factors.size() != height() &&
+        zero_points.size() != height()) {
+      throw std::invalid_argument("Error: output axis do not match ");
+    }
+
+    if (axis == 3 && scale_factors.size() != width() &&
+        zero_points.size() != width()) {
+      throw std::invalid_argument("Error: output axis do not match ");
+    }
+
     int idx;
     for (unsigned int b = 0; b < batch(); ++b) {
       for (unsigned int c = 0; c < channel(); ++c) {
         for (unsigned int h = 0; h < height(); ++h) {
           for (unsigned int w = 0; w < width(); ++w) {
-            if (output_axis == 0)
+            if (axis == 0)
               idx = b;
-            else if (output_axis == 1)
+            else if (axis == 1)
               idx = c;
-            else if (output_axis == 2)
+            else if (axis == 2)
               idx = h;
-            else if (output_axis == 3)
+            else if (axis == 3)
               idx = w;
 
             if (getDataType() == Tdatatype::QINT8) {
@@ -2077,7 +2088,6 @@ private:
   std::string name; /**< name of the tensor */
   std::shared_ptr<MemoryData> data;
   size_t offset;
-  int output_axis;
   std::vector<float> scale_factors;
   std::vector<uint8_t> zero_points;
 

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -4354,13 +4354,12 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
 
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 4, 7});
 
   nntrainer::Tensor output(batch, channel, height, width);
 
-  EXPECT_THROW({ input.dequantize<float>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4376,13 +4375,12 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     batch + 1, channel, height + 1, width + 1,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 4, 7});
 
   nntrainer::Tensor output(batch, channel, height, width);
 
-  EXPECT_THROW({ input.dequantize<float>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4401,7 +4399,7 @@ TEST(nntrainer_Tensor, dequantize_03_n) {
 
   nntrainer::Tensor output(batch, channel, height, width);
 
-  EXPECT_THROW({ input.dequantize<float>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4417,15 +4415,15 @@ TEST(nntrainer_Tensor, dequantize_04_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
-  EXPECT_THROW(
-    {
-      input.setScaleFactors({2.0, 1.5, 1.0, 0.5});
-    },
-    std::invalid_argument);
 
-  input.setOutputAxis(2);
-  EXPECT_NO_THROW({ input.setScaleFactors({2.0, 1.5, 1.0, 0.5}); });
+  nntrainer::Tensor output(
+    batch, channel, height, width,
+    {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
+
+  input.setScaleFactors({2.0, 1.5, 1.0, 0.5});
+  input.setZeroPoints({2, 3, 4, 5});
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
 }
 
 /**
@@ -4441,7 +4439,6 @@ TEST(nntrainer_Tensor, dequantize_05_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 4, 7});
 
@@ -4449,7 +4446,7 @@ TEST(nntrainer_Tensor, dequantize_05_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
 
-  EXPECT_THROW({ input.dequantize<float>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4471,10 +4468,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   nntrainer::Tensor output(batch, channel, height, width);
 
   // Dequantize by channel
-  EXPECT_NO_THROW(input.setOutputAxis(1));
   EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output); });
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 1); });
 
   float answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
                            -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
@@ -4490,10 +4486,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  EXPECT_NO_THROW(input.setOutputAxis(2));
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4.8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output); });
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
 
   float answer_data_2[] = {
     -4.2, -4.2, -4.2, -4.2, -4.2, -2,   -2,   -2,   -2,   -2,   2,    2,
@@ -4509,10 +4504,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  EXPECT_NO_THROW(input.setOutputAxis(3));
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output); });
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 3); });
 
   float answer_data_3[] = {
     -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8,
@@ -4547,10 +4541,9 @@ TEST(nntrainer_Tensor, dequantize_08_p) {
   nntrainer::Tensor output(batch, channel, height, width);
 
   // Dequantize by channel
-  EXPECT_NO_THROW(input.setOutputAxis(1));
   EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output); });
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 1); });
 
   float answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
                            -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
@@ -4566,10 +4559,9 @@ TEST(nntrainer_Tensor, dequantize_08_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  EXPECT_NO_THROW(input.setOutputAxis(2));
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output); });
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
 
   float answer_data_2[] = {-4.2, -4.2, -4.2, -4.2, -4.2, -2, -2, -2, -2, -2,
                            2,    2,    2,    2,    2,    4,  4,  4,  4,  4,
@@ -4585,10 +4577,9 @@ TEST(nntrainer_Tensor, dequantize_08_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  EXPECT_NO_THROW(input.setOutputAxis(3));
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output); });
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 3); });
 
   float answer_data_3[] = {
     -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8,

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -5859,7 +5859,6 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
   nntrainer::Tensor input(batch, channel, height, width,
                           nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 4, 7});
 
@@ -5867,7 +5866,7 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5884,7 +5883,6 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
 
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 4, 7});
 
@@ -5892,7 +5890,7 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5913,7 +5911,7 @@ TEST(nntrainer_Tensor, dequantize_03_n) {
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5929,13 +5927,12 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({0, 0, 0});
 
   nntrainer::Tensor output;
 
-  EXPECT_NO_THROW({ output = input.dequantize<_FP16>(); });
+  EXPECT_NO_THROW({ output = input.dequantize<_FP16>(1); });
 
   _FP16 answer_data[] = {
     static_cast<_FP16>(1.5), static_cast<_FP16>(1.5), static_cast<_FP16>(1.5),
@@ -5988,10 +5985,9 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
                            nntrainer::Tdatatype::FP16);
 
   // Dequantize by channel
-  input.setOutputAxis(1);
   EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 1); });
 
   _FP16 answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
                            -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
@@ -6007,10 +6003,9 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  input.setOutputAxis(2);
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4.8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 2); });
 
   _FP16 answer_data_2[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
                            static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
@@ -6050,10 +6045,9 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  input.setOutputAxis(3);
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 3); });
 
   _FP16 answer_data_3[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
                            static_cast<_FP16>(2),    static_cast<_FP16>(4),
@@ -6115,10 +6109,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
                            nntrainer::Tdatatype::FP16);
 
   // Dequantize by channel
-  input.setOutputAxis(1);
   EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 1); });
 
   _FP16 answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
                            -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
@@ -6134,10 +6127,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  input.setOutputAxis(2);
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 2); });
 
   _FP16 answer_data_2[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
                            static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
@@ -6177,10 +6169,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  input.setOutputAxis(3);
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 3); });
 
   _FP16 answer_data_3[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
                            static_cast<_FP16>(2),    static_cast<_FP16>(4),

--- a/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
@@ -4688,7 +4688,6 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 0, 3});
 
@@ -4696,7 +4695,7 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::FP32});
 
-  EXPECT_THROW({ input.dequantize<float>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4712,7 +4711,6 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 0, 3});
 
@@ -4720,7 +4718,7 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
 
-  EXPECT_THROW({ input.dequantize<float>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4736,14 +4734,13 @@ TEST(nntrainer_Tensor, dequantize_03_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({5, 5, 5});
 
   nntrainer::Tensor output;
   output.getDim().setFormat(nntrainer::Tformat::NHWC);
 
-  EXPECT_NO_THROW({ output = input.dequantize<float>(); });
+  EXPECT_NO_THROW({ output = input.dequantize<float>(1); });
 
   float answer_data[] = {
     -6,   1, 3,   -6,   1, 3,   -6,   1, 3,   -6,   1, 3,   -6,   1, 3,
@@ -4772,7 +4769,6 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setOutputAxis(2);
   input.setScaleFactors({2.5, 2.0, 1.5, 1.0});
   input.setZeroPoints({8, 8, 8, 8});
 
@@ -4780,7 +4776,7 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::FP32});
 
-  EXPECT_NO_THROW({ input.dequantize<float>(output); });
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
 
   float answer_data[] = {
     -17.5, -5, 7.5, -17.5, -5, 7.5, -17.5, -5, 7.5, -17.5, -5, 7.5,
@@ -4815,13 +4811,12 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
      {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT4}},
     true, nntrainer::Tensor::Initializer::ZEROS);
 
-  input.setOutputAxis(1);
   input.setScaleFactors({8, 6, 4, 2, 1, -1, -2, -4, -6, -7});
   input.setZeroPoints({1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
 
   nntrainer::Tensor output;
 
-  EXPECT_NO_THROW({ output = input.dequantize<float>(); });
+  EXPECT_NO_THROW({ output = input.dequantize<float>(1); });
 
   float answer_data[] = {-8, -6, -4, -2, -1, 1, 2, 4, 6, 7,
                          -8, -6, -4, -2, -1, 1, 2, 4, 6, 7};


### PR DESCRIPTION
## Commits to be reviewed in this PR

<details><summary>   [Tensor] Read quantized tensor from binary file </summary><br />

This patch adds functionality to read quantized tensors from a binary file. Details are as follows.

- Read the tensor in the following order (axis, scale factors, zero points, and values).
- Tensor::read takes an extra argument of datatype to identify the datatype of scale factors and read exact bytes.
- Dequantize function takes the output axis as a parameter instead of the tensor having an axis variable.
- Fix QINT4 tensor print segfault issue.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by:Donghyeon Jeong <dhyeon.jeong@samsung.com>
</details>
