### PR TITLE
[sgemm] fp32 implementation with inline function calls

### DIFF
--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1000,36 +1000,52 @@ void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
                      uint32_t N, uint32_t K, float alpha, float beta,
                      bool TransA, bool TransB) {
 
-  float16x8_t v_beta = vmovq_n_f16(beta);
+  // dynamic creation to avoid reaching stack limit(causes sgementation fault)
+  float *C32 = (float *)malloc(M * N * sizeof(float));
 
   // performing beta*C
   unsigned int idx = 0;
   unsigned int size = M * N;
   for (; idx < (size - idx) >= 8; idx += 8) {
     float16x8_t c = vld1q_f16(&C[idx]);
-    c = vmulq_f16(v_beta, c);
-    vst1q_f16(&C[idx], c);
+
+    float32x4_t c0_3 = vmulq_n_f32(vcvt_f32_f16(vget_low_f16(c)), beta);
+    float32x4_t c4_7 = vmulq_n_f32(vcvt_f32_f16(vget_high_f16(c)), beta);
+
+    vst1q_f32(&C32[idx], c0_3);
+    vst1q_f32(&C32[idx + 4], c4_7);
+  }
+  // remaining 4
+  for (; idx < (size - idx) >= 4; idx += 4) {
+    float16x4_t c = vld1_f16(&C[idx]);
+
+    float32x4_t c0_3 = vmulq_n_f32(vcvt_f32_f16(c), beta);
+
+    vst1q_f32(&C32[idx], c0_3);
   }
 
   // remaining values if dimensions not a multiple of 8
   for (; idx < size; idx++) {
-    C[idx] *= beta;
+    C32[idx] = C[idx] * beta;
   }
 
   if (!TransA && TransB) {
-    sgemm_neon_fp16_transB(A, B, C, M, N, K, alpha, beta);
+    sgemm_neon_fp16_transB(A, B, C32, M, N, K, alpha, beta);
   } else if (TransA && !TransB) {
-    sgemm_neon_fp16_transA(A, B, C, M, N, K, alpha, beta);
+    sgemm_neon_fp16_transA(A, B, C32, M, N, K, alpha, beta);
   } else if (!TransA && !TransB) {
-    sgemm_neon_fp16_noTrans(A, B, C, M, N, K, alpha, beta);
+    sgemm_neon_fp16_noTrans(A, B, C32, M, N, K, alpha, beta);
   } else { // TransA && TransB
-    sgemm_neon_fp16_transAB(A, B, C, M, N, K, alpha, beta, idx);
+    sgemm_neon_fp16_transAB(A, B, C32, M, N, K, alpha, beta, idx);
   }
+
+  scopy_neon_fp32_to_fp16(M * N, C32, C);
+  free(C32);
 }
 
-void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
-                             uint32_t M, uint32_t N, uint32_t K, float alpha,
-                             float beta) {
+void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B,
+                                      float *C, uint32_t M, uint32_t N,
+                                      uint32_t K, float alpha, float beta) {
 
   unsigned int k = 0, n = 0;
 
@@ -1045,66 +1061,58 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
       float a7 = alpha * A[m * K + k + 7];
 
       for (n = 0; (N - n) >= 8; n += 8) {
-        float32x4_t b0_7_0_low = vcvt_f32_f16(vld1_f16(&B[k * N + n]));
-        float32x4_t b0_7_0_high = vcvt_f32_f16(vld1_f16(&B[k * N + n + 4]));
+        float16x8_t b0_7_0 = vld1q_f16(&B[k * N + n]);
+        float16x8_t b0_7_1 = vld1q_f16(&B[(k + 1) * N + n]);
+        float16x8_t b0_7_2 = vld1q_f16(&B[(k + 2) * N + n]);
+        float16x8_t b0_7_3 = vld1q_f16(&B[(k + 3) * N + n]);
+        float16x8_t b0_7_4 = vld1q_f16(&B[(k + 4) * N + n]);
+        float16x8_t b0_7_5 = vld1q_f16(&B[(k + 5) * N + n]);
+        float16x8_t b0_7_6 = vld1q_f16(&B[(k + 6) * N + n]);
+        float16x8_t b0_7_7 = vld1q_f16(&B[(k + 7) * N + n]);
 
-        float32x4_t b0_7_1_low = vcvt_f32_f16(vld1_f16(&B[(k + 1) * N + n]));
-        float32x4_t b0_7_1_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 1) * N + n + 4]));
+        float32x4_t c0_7_low_32 = vfmaq_n_f32(
+          vld1q_f32(&C[m * N + n]), vcvt_f32_f16(vget_low_f16(b0_7_0)), a0);
+        float32x4_t c0_7_high_32 =
+          vfmaq_n_f32(vld1q_f32(&C[m * N + n + 4]),
+                      vcvt_f32_f16(vget_high_f16(b0_7_0)), a0);
 
-        float32x4_t b0_7_2_low = vcvt_f32_f16(vld1_f16(&B[(k + 2) * N + n]));
-        float32x4_t b0_7_2_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 2) * N + n + 4]));
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_1)), a1);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_1)), a1);
 
-        float32x4_t b0_7_3_low = vcvt_f32_f16(vld1_f16(&B[(k + 3) * N + n]));
-        float32x4_t b0_7_3_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 3) * N + n + 4]));
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_2)), a2);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_2)), a2);
 
-        float32x4_t b0_7_4_low = vcvt_f32_f16(vld1_f16(&B[(k + 4) * N + n]));
-        float32x4_t b0_7_4_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 4) * N + n + 4]));
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_3)), a3);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_3)), a3);
 
-        float32x4_t b0_7_5_low = vcvt_f32_f16(vld1_f16(&B[(k + 5) * N + n]));
-        float32x4_t b0_7_5_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 5) * N + n + 4]));
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_4)), a4);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_4)), a4);
 
-        float32x4_t b0_7_6_low = vcvt_f32_f16(vld1_f16(&B[(k + 6) * N + n]));
-        float32x4_t b0_7_6_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 6) * N + n + 4]));
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_5)), a5);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_5)), a5);
 
-        float32x4_t b0_7_7_low = vcvt_f32_f16(vld1_f16(&B[(k + 7) * N + n]));
-        float32x4_t b0_7_7_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 7) * N + n + 4]));
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_6)), a6);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_6)), a6);
 
-        float32x4_t c0_7_low_32 = vcvt_f32_f16(vld1_f16(&C[m * N + n]));
-        float32x4_t c0_7_high_32 = vcvt_f32_f16(vld1_f16(&C[m * N + n + 4]));
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_7)), a7);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_7)), a7);
 
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_0_low, a0);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_0_high, a0);
-
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_1_low, a1);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_1_high, a1);
-
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_2_low, a2);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_2_high, a2);
-
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_3_low, a3);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_3_high, a3);
-
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_4_low, a4);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_4_high, a4);
-
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_5_low, a5);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_5_high, a5);
-
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_6_low, a6);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_6_high, a6);
-
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_7_low, a7);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_7_high, a7);
-
-        vst1q_f16(&C[m * N + n], vcombine_f16(vcvt_f16_f32(c0_7_low_32),
-                                              vcvt_f16_f32(c0_7_high_32)));
+        vst1q_f32(&C[m * N + n], c0_7_low_32);
+        vst1q_f32(&C[m * N + n + 4], c0_7_high_32);
       }
     }
   }
@@ -1122,35 +1130,29 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
         float16x8_t b0_7_2 = vld1q_f16(&B[(k + 2) * N + n]);
         float16x8_t b0_7_3 = vld1q_f16(&B[(k + 3) * N + n]);
 
-        float32x4_t b0_7_0_low = vcvt_f32_f16(vld1_f16(&B[k * N + n]));
-        float32x4_t b0_7_0_high = vcvt_f32_f16(vld1_f16(&B[k * N + n + 4]));
-        float32x4_t b0_7_1_low = vcvt_f32_f16(vld1_f16(&B[(k + 1) * N + n]));
-        float32x4_t b0_7_1_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 1) * N + n + 4]));
-        float32x4_t b0_7_2_low = vcvt_f32_f16(vld1_f16(&B[(k + 2) * N + n]));
-        float32x4_t b0_7_2_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 2) * N + n + 4]));
-        float32x4_t b0_7_3_low = vcvt_f32_f16(vld1_f16(&B[(k + 3) * N + n]));
-        float32x4_t b0_7_3_high =
-          vcvt_f32_f16(vld1_f16(&B[(k + 3) * N + n + 4]));
+        float32x4_t c0_7_low_32 = vfmaq_n_f32(
+          vld1q_f32(&C[m * N + n]), vcvt_f32_f16(vget_low_f16(b0_7_0)), a0);
+        float32x4_t c0_7_high_32 =
+          vfmaq_n_f32(vld1q_f32(&C[m * N + n + 4]),
+                      vcvt_f32_f16(vget_high_f16(b0_7_0)), a0);
 
-        float32x4_t c0_7_low_32 = vcvt_f32_f16(vld1_f16(&C[m * N + n]));
-        float32x4_t c0_7_high_32 = vcvt_f32_f16(vld1_f16(&C[m * N + n + 4]));
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_1)), a1);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_1)), a1);
 
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_0_low, a0);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_0_high, a0);
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_2)), a2);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_2)), a2);
 
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_1_low, a1);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_1_high, a1);
+        c0_7_low_32 =
+          vfmaq_n_f32(c0_7_low_32, vcvt_f32_f16(vget_low_f16(b0_7_3)), a3);
+        c0_7_high_32 =
+          vfmaq_n_f32(c0_7_high_32, vcvt_f32_f16(vget_high_f16(b0_7_3)), a3);
 
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_2_low, a2);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_2_high, a2);
-
-        c0_7_low_32 = vfmaq_n_f32(c0_7_low_32, b0_7_3_low, a3);
-        c0_7_high_32 = vfmaq_n_f32(c0_7_high_32, b0_7_3_high, a3);
-
-        vst1q_f16(&C[m * N + n], vcombine_f16(vcvt_f16_f32(c0_7_low_32),
-                                              vcvt_f16_f32(c0_7_high_32)));
+        vst1q_f32(&C[m * N + n], c0_7_low_32);
+        vst1q_f32(&C[m * N + n + 4], c0_7_high_32);
       }
     }
   }
@@ -1158,37 +1160,43 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
   // remaining K values
   for (; k < K; k++) {
     for (unsigned int m = 0; m < M; m++) {
-      __fp16 a0 = alpha * A[m * K + k];
+      float a0 = alpha * A[m * K + k];
 
       for (n = 0; (N - n) >= 8; n += 8) {
         float16x8_t b0_7 = vld1q_f16(&B[k * N + n]);
 
-        float16x8_t c0_7 = vld1q_f16(&C[m * N + n]);
+        float32x4_t c0_7_low_32 = vfmaq_n_f32(
+          vld1q_f32(&C[m * N + n]), vcvt_f32_f16(vget_low_f16(b0_7)), a0);
+        float32x4_t c0_7_high_32 = vfmaq_n_f32(
+          vld1q_f32(&C[m * N + n + 4]), vcvt_f32_f16(vget_high_f16(b0_7)), a0);
 
-        c0_7 = vfmaq_n_f16(c0_7, b0_7, a0);
-
-        vst1q_f16(&C[m * N + n], c0_7);
+        vst1q_f32(&C[m * N + n], c0_7_low_32);
+        vst1q_f32(&C[m * N + n + 4], c0_7_high_32);
       }
     }
   }
 
-  // remaining N values (can be optimized by putting inside previous loops)
+  // remaining N values
   if (n < N) {
-    __fp16 valsB[8];
-    __fp16 valsC[8];
+    float valsB[8];
+    float valsC[8];
     for (k = 0; k < K; k++) {
       for (unsigned int m = 0; m < M; m++) {
-        __fp16 a = alpha * A[m * K + k];
+        float a = alpha * A[m * K + k];
         for (unsigned int idx = n; idx < N; idx++) {
           valsB[idx - n] = B[k * N + idx];
 
           // load previously calculated C
           valsC[idx - n] = C[m * N + idx];
         }
-        float16x8_t b = vld1q_f16(valsB);
-        float16x8_t c = vld1q_f16(valsC);
-        c = vfmaq_n_f16(c, b, a);
-        vst1q_f16(valsC, c);
+
+        float32x4_t c0_7_low_32 =
+          vfmaq_n_f32(vld1q_f32(valsC), vld1q_f32(valsB), a);
+        float32x4_t c0_7_high_32 =
+          vfmaq_n_f32(vld1q_f32(valsC + 4), vld1q_f32(valsB + 4), a);
+
+        vst1q_f32(valsC, c0_7_low_32);
+        vst1q_f32(valsC + 4, c0_7_high_32);
 
         for (unsigned int idx = n; idx < N; idx++) {
           C[m * N + idx] = valsC[idx - n];
@@ -1198,22 +1206,25 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
   }
 }
 
-void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, __fp16 *C,
-                            uint32_t M, uint32_t N, uint32_t K, float alpha,
-                            float beta) {
-  __fp16 valsB[8];
-  __fp16 valsC[8];
+void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
+                                     uint32_t M, uint32_t N, uint32_t K,
+                                     float alpha, float beta) {
+  float valsB[8];
+  float valsC[8];
   for (unsigned int k = 0; k < K; k++) {
     for (unsigned int m = 0; m < M; m++) {
-      __fp16 a = alpha * A[k * M + m];
+      float a = alpha * A[k * M + m];
       unsigned int n = 0;
       for (; (N - n) >= 8; n += 8) {
         float16x8_t b = vld1q_f16(&B[k * N + n]);
 
-        // load previously calculated C
-        float16x8_t c = vld1q_f16(&C[m * N + n]);
-        c = vfmaq_n_f16(c, b, a);
-        vst1q_f16(&C[m * N + n], c);
+        float32x4_t c0_7_low_32 = vfmaq_n_f32(vld1q_f32(&C[m * N + n]),
+                                              vcvt_f32_f16(vget_low_f16(b)), a);
+        float32x4_t c0_7_high_32 = vfmaq_n_f32(
+          vld1q_f32(&C[m * N + n + 4]), vcvt_f32_f16(vget_high_f16(b)), a);
+
+        vst1q_f32(&C[m * N + n], c0_7_low_32);
+        vst1q_f32(&C[m * N + n + 4], c0_7_high_32);
       }
 
       // remaining N values
@@ -1224,10 +1235,14 @@ void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, __fp16 *C,
           // load previously calculated C
           valsC[idx - n] = C[m * N + idx];
         }
-        float16x8_t b = vld1q_f16(valsB);
-        float16x8_t c = vld1q_f16(valsC);
-        c = vfmaq_n_f16(c, b, a);
-        vst1q_f16(valsC, c);
+
+        float32x4_t c0_7_low_32 =
+          vfmaq_n_f32(vld1q_f32(valsC), vld1q_f32(valsB), a);
+        float32x4_t c0_7_high_32 =
+          vfmaq_n_f32(vld1q_f32(valsC + 4), vld1q_f32(valsB + 4), a);
+
+        vst1q_f32(valsC, c0_7_low_32);
+        vst1q_f32(valsC + 4, c0_7_high_32);
 
         for (unsigned int idx = n; idx < N; idx++) {
           C[m * N + idx] = valsC[idx - n];
@@ -1237,33 +1252,29 @@ void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, __fp16 *C,
   }
 }
 
-void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
-                            uint32_t M, uint32_t N, uint32_t K, float alpha,
-                            float beta) {
-  __fp16 r[4];
-  float16x8_t v_alpha = vmovq_n_f16(alpha);
+void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
+                                     uint32_t M, uint32_t N, uint32_t K,
+                                     float alpha, float beta) {
   if (K % 16 == 0) {
     for (unsigned int m = 0; m < M; m++) {
       for (unsigned int n = 0; n < N; n++) {
+        // float16x8_t sum = vmovq_n_f16(0);
         float32x4_t sum = vmovq_n_f32(0.0f);
         unsigned int k = 0;
         for (; (K - k) >= 16; k += 16) {
-          float32x4_t a_low = vcvt_f32_f16(vld1_f16(&A[m * K + k]));
-          float32x4_t a_high = vcvt_f32_f16(vld1_f16(&A[m * K + k + 4]));
+          float16x8_t a = vld1q_f16(&A[m * K + k]);
+          float16x8_t a8_15 = vld1q_f16(&A[m * K + k + 8]);
+          float16x8_t b = vld1q_f16(&B[n * K + k]);
+          float16x8_t b8_15 = vld1q_f16(&B[n * K + k + 8]);
 
-          float32x4_t a8_15_low = vcvt_f32_f16(vld1_f16(&A[m * K + k + 8]));
-          float32x4_t a8_15_high = vcvt_f32_f16(vld1_f16(&A[m * K + k + 12]));
-
-          float32x4_t b_low = vcvt_f32_f16(vld1_f16(&B[n * K + k]));
-          float32x4_t b_high = vcvt_f32_f16(vld1_f16(&B[n * K + k + 4]));
-
-          float32x4_t b8_15_low = vcvt_f32_f16(vld1_f16(&B[n * K + k + 8]));
-          float32x4_t b8_15_high = vcvt_f32_f16(vld1_f16(&B[n * K + k + 12]));
-
-          sum = vfmaq_f32(sum, a_low, b_low);
-          sum = vfmaq_f32(sum, a_high, b_high);
-          sum = vfmaq_f32(sum, a8_15_low, b8_15_low);
-          sum = vfmaq_f32(sum, a8_15_high, b8_15_high);
+          sum = vfmaq_f32(sum, vcvt_f32_f16(vget_low_f16(a)),
+                          vcvt_f32_f16(vget_low_f16(b)));
+          sum = vfmaq_f32(sum, vcvt_f32_f16(vget_high_f16(a)),
+                          vcvt_f32_f16(vget_high_f16(b)));
+          sum = vfmaq_f32(sum, vcvt_f32_f16(vget_low_f16(a8_15)),
+                          vcvt_f32_f16(vget_low_f16(b8_15)));
+          sum = vfmaq_f32(sum, vcvt_f32_f16(vget_high_f16(a8_15)),
+                          vcvt_f32_f16(vget_high_f16(b8_15)));
         }
 
         sum = vmulq_n_f32(sum, alpha);
@@ -1272,21 +1283,20 @@ void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
       }
     }
   } else {
-    __fp16 valsB[8];
-    __fp16 valsA[8];
+    float valsB[8];
+    float valsA[8];
     for (unsigned int m = 0; m < M; m++) {
       for (unsigned int n = 0; n < N; n++) {
         float32x4_t sum = vmovq_n_f32(0.0f);
         unsigned int k = 0;
         for (; (K - k) >= 8; k += 8) {
-          float32x4_t a_low = vcvt_f32_f16(vld1_f16(&A[m * K + k]));
-          float32x4_t a_high = vcvt_f32_f16(vld1_f16(&A[m * K + k + 4]));
+          float16x8_t a = vld1q_f16(&A[m * K + k]);
+          float16x8_t b = vld1q_f16(&B[n * K + k]);
 
-          float32x4_t b_low = vcvt_f32_f16(vld1_f16(&B[n * K + k]));
-          float32x4_t b_high = vcvt_f32_f16(vld1_f16(&B[n * K + k + 4]));
-
-          sum = vfmaq_f32(sum, a_low, b_low);
-          sum = vfmaq_f32(sum, a_high, b_high);
+          sum = vfmaq_f32(sum, vcvt_f32_f16(vget_low_f16(a)),
+                          vcvt_f32_f16(vget_low_f16(b)));
+          sum = vfmaq_f32(sum, vcvt_f32_f16(vget_high_f16(a)),
+                          vcvt_f32_f16(vget_high_f16(b)));
         }
 
         // remaining K values
@@ -1302,15 +1312,10 @@ void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
             valsB[idx - k] = 0;
             idx++;
           }
+
           // updating sum
-          float32x4_t a_low = vcvt_f32_f16(vld1_f16(&valsA[0]));
-          float32x4_t a_high = vcvt_f32_f16(vld1_f16(&valsA[4]));
-
-          float32x4_t b_low = vcvt_f32_f16(vld1_f16(&valsB[0]));
-          float32x4_t b_high = vcvt_f32_f16(vld1_f16(&valsB[4]));
-
-          sum = vfmaq_f32(sum, a_low, b_low);
-          sum = vfmaq_f32(sum, a_high, b_high);
+          sum = vfmaq_f32(sum, vld1q_f32(valsA), vld1q_f32(valsB));
+          sum = vfmaq_f32(sum, vld1q_f32(valsA + 4), vld1q_f32(valsB + 4));
         }
 
         sum = vmulq_n_f32(sum, alpha);
@@ -1321,19 +1326,23 @@ void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
   }
 }
 
-void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, __fp16 *C,
-                             uint32_t M, uint32_t N, uint32_t K, float alpha,
-                             float beta, uint32_t idx) {
-  __fp16 vals[8];
+void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B,
+                                      float *C, uint32_t M, uint32_t N,
+                                      uint32_t K, float alpha, float beta,
+                                      uint32_t idx) {
+  float vals[8];
   for (unsigned int n = 0; n < N; n++) {
     for (unsigned int k = 0; k < K; k++) {
 
-      __fp16 b = alpha * B[n * K + k];
+      float b = alpha * B[n * K + k];
       unsigned int m = 0;
       for (; (M - m) >= 8; m += 8) {
         float16x8_t a = vld1q_f16(&A[k * M + m]);
-        a = vmulq_n_f16(a, b);
-        vst1q_f16(vals, a);
+
+        float32x4_t a_low = vmulq_n_f32(vcvt_f32_f16(vget_low_f16(a)), b);
+        float32x4_t a_high = vmulq_n_f32(vcvt_f32_f16(vget_high_f16(a)), b);
+        vst1q_f32(vals, a_low);
+        vst1q_f32(vals + 4, a_high);
 
         // calculations for all M values
         for (unsigned int idx = m; idx < m + 8; idx++)
@@ -1346,9 +1355,10 @@ void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, __fp16 *C,
           vals[idx - m] = A[k * M + idx];
         }
 
-        float16x8_t a = vld1q_f16(vals);
-        a = vmulq_n_f16(a, b);
-        vst1q_f16(vals, a);
+        float32x4_t a_low = vmulq_n_f32(vld1q_f32(vals), b);
+        float32x4_t a_high = vmulq_n_f32(vld1q_f32(vals + 4), b);
+        vst1q_f32(vals, a_low);
+        vst1q_f32(vals + 4, a_high);
 
         // calculations for all remaining M values
         for (idx = m; idx < M; idx++)

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -183,7 +183,7 @@ void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
+void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta);
 /**
@@ -198,7 +198,7 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, __fp16 *C,
+void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta);
 /**
@@ -213,7 +213,7 @@ void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, __fp16 *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
+void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta);
 /**
@@ -228,7 +228,7 @@ void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, __fp16 *C,
+void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta, uint32_t idx);
 #endif


### PR DESCRIPTION
**SGEMM** modifications made:

- Implemented using fp32 intrinsics.
- Modified function calls to inline calls to reduce register spilling.
- Dynamically allocated temporary fp32 storage used to enhance accuracy.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by:s-debadri <s.debadri@samsung.com>