### PR TITLE
[tasks] add plan for multi-model nntr_config support

### DIFF
--- a/Applications/CausalLM/res/qwen3/qwen3-0.6b-stacked/nntr_config.json
+++ b/Applications/CausalLM/res/qwen3/qwen3-0.6b-stacked/nntr_config.json
@@ -1,0 +1,29 @@
+{
+    "model_type": "CausalLM",
+    "model_tensor_type": "FP32-FP32",
+
+    "architectures": ["Qwen3ForCausalLM", "Qwen3ForCausalLM"],
+    "model_dirs": ["../qwen3-0.6b", "../qwen3-0.6b"],
+    "model_file_names": [
+        "nntr_qwen3_0.6b_fp32.bin",
+        "nntr_qwen3_0.6b_fp32.bin"
+    ],
+
+    "fc_layer_dtype": "FP32",
+    "embedding_dtype": "FP32",
+
+    "lora_rank": 0,
+    "lora_alpha": 0,
+    "lora_target": [],
+
+    "bad_word_ids": [],
+    "fsu": false,
+    "fsu_lookahead": 2,
+    "num_to_generate": 128,
+    "init_seq_len": 1024,
+    "max_seq_len": 2048,
+    "batch_size": 1,
+
+    "tokenizer_file": "/tmp/nntrainer/Applications/CausalLM/res/qwen3/qwen3-0.6b/tokenizer.json",
+    "sample_input": "<|im_start|>user\nGive me a short introduction to large language model.<|im_end|>\n<|im_start|>assistant\n"
+}

--- a/Applications/CausalLM/res/qwen3/qwen3-0.6b-stacked/nntr_config.json
+++ b/Applications/CausalLM/res/qwen3/qwen3-0.6b-stacked/nntr_config.json
@@ -1,29 +1,4 @@
 {
-    "model_type": "CausalLM",
-    "model_tensor_type": "FP32-FP32",
-
     "architectures": ["Qwen3ForCausalLM", "Qwen3ForCausalLM"],
-    "model_dirs": ["../qwen3-0.6b", "../qwen3-0.6b"],
-    "model_file_names": [
-        "nntr_qwen3_0.6b_fp32.bin",
-        "nntr_qwen3_0.6b_fp32.bin"
-    ],
-
-    "fc_layer_dtype": "FP32",
-    "embedding_dtype": "FP32",
-
-    "lora_rank": 0,
-    "lora_alpha": 0,
-    "lora_target": [],
-
-    "bad_word_ids": [],
-    "fsu": false,
-    "fsu_lookahead": 2,
-    "num_to_generate": 128,
-    "init_seq_len": 1024,
-    "max_seq_len": 2048,
-    "batch_size": 1,
-
-    "tokenizer_file": "/tmp/nntrainer/Applications/CausalLM/res/qwen3/qwen3-0.6b/tokenizer.json",
-    "sample_input": "<|im_start|>user\nGive me a short introduction to large language model.<|im_end|>\n<|im_start|>assistant\n"
+    "model_dirs": ["../qwen3-0.6b", "../qwen3-0.6b"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+## Workflow Orchestration
+
+### 1. Plan Node Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main contect window clean
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One tack per subagent for focused execution
+
+### 3. Self-Improvememnt Loop
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verificatin Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, chvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When givne a bug report: jst fix it. Don't ask for hand-holding
+- Point a logs, errors, failing tests -then resolve them
+- Zero context switching requried from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items
+2. **Verify Plan**: Check in before starting implementation
+3. **Track Progress**: Mark items complete as you go
+4. **Explain Changes**: High-level summary at each step
+5. **Document Results**: Add review section to `tasks/todo.md`
+6. **Capture Lessons**: Update `tasks/lessons.md` after corrections
+
+## Core Principles
+
+- **Simplicity First**: Make every change as simple as possible. Inpact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,129 @@
+# Multi-Model nntr_config Support
+
+## Goal
+Extend Applications/CausalLM so that a single top-level `nntr_config.json`
+can describe multiple sub-models (e.g. vision-encoder + LLM, or Linear +
+Qwen3-0.6B). Move `architectures` out of HF `config.json` into the per-model
+entry of `nntr_config.json`. Each sub-model lives in its own directory with
+its own `config.json` / `generation_config.json` / weight file.
+
+## Design
+
+### Top-level `nntr_config.json` (multi-model) schema
+
+```json
+{
+    "model_tensor_type": "FP32-FP32",
+    "tokenizer_file": "/abs/path/to/tokenizer.json",
+    "sample_input": "...",
+    "num_to_generate": 128,
+    "init_seq_len": 1024,
+    "max_seq_len": 2048,
+    "batch_size": 1,
+    "bad_word_ids": [],
+    "fsu": false,
+    "fsu_lookahead": 2,
+
+    "models": [
+        {
+            "name":  "prelinear",
+            "architecture": "LinearCausalLM",
+            "dir":   "linear_model",
+            "model_file_name": "nntr_linear.bin",
+            "model_type": "CausalLM",
+            "fc_layer_dtype": "FP32",
+            "embedding_dtype": "FP32"
+        },
+        {
+            "name":  "qwen3",
+            "architecture": "Qwen3ForCausalLM",
+            "dir":   "qwen3-0.6b",
+            "model_file_name": "nntr_qwen3_0.6b_fp32.bin",
+            "model_type": "CausalLM",
+            "fc_layer_dtype": "FP32",
+            "embedding_dtype": "FP32"
+        }
+    ]
+}
+```
+
+### Per-sub-model directory layout
+
+```
+res/multi_example/
+├── nntr_config.json            # top-level (above)
+├── linear_model/
+│   ├── config.json             # HF-ish, no "architectures" field
+│   └── generation_config.json
+└── qwen3-0.6b/
+    ├── config.json             # standard HF Qwen3 config w/o architectures
+    └── generation_config.json
+```
+
+Weight file locations follow `model_file_name` relative to the sub-model dir.
+
+### Config-loading rules
+- `architecture` comes from the sub-model entry in `nntr_config.json`.
+- Per-sub-model `config.json` provides HF dims; `architectures` field (if
+  still present) is ignored.
+- Top-level nntr keys (tokenizer_file, batch_size, max_seq_len, fsu, ...) are
+  shared; per-sub-model keys override them.
+- Each sub-model sees a *synthesized* `nntr_cfg` = top-level keys merged
+  with its own entry fields, so existing `setupParameters(...)` code works
+  unchanged.
+
+### Orchestration
+For this PR we only wire up *independent load/initialize* for N models.
+Actual pipelining (vision→LLM, logit fusion, etc.) is future work. The
+binary runs the **last** model in `models` against `sample_input` so the
+existing single-model run path is preserved; earlier models are just loaded
+and initialized (demonstrates that multiple models co-exist).
+
+### Backward compatibility
+`main.cpp` detects multi-model mode by presence of `"models"` array in
+`nntr_config.json`. Otherwise it falls through to the current single-model
+path unchanged.
+
+## Tasks
+
+- [ ] Implement `LinearCausalLM` at `models/linear/linear_causallm.{h,cpp}`
+      — a `CausalLM` subclass whose `constructModel()` is just
+      `input → embedding → fully_connected → lm_head` (no transformer
+      blocks, no RoPE/attention). Override `setupParameters` to tolerate
+      missing transformer-specific fields.
+- [ ] Add `subdir('linear')` to `Applications/CausalLM/models/meson.build`
+      and a `linear/meson.build` mirroring `qwen3/meson.build`.
+- [ ] Register `"LinearCausalLM"` factory entry in `main.cpp`.
+- [ ] Refactor `main.cpp`:
+  - Detect `nntr_cfg["models"]`.
+  - For each entry: build per-model `nntr_sub_cfg` by deep-copying top-level
+    and overlaying entry fields; load `<model_path>/<dir>/config.json` and
+    `<model_path>/<dir>/generation_config.json`; call
+    `Factory::create(architecture, cfg, gen, nntr_sub_cfg)`; `initialize()`;
+    `load_weight(<model_path>/<dir>/<model_file_name>)`.
+  - Keep the current legacy path when `"models"` is absent.
+  - Change architecture resolution: prefer per-entry `architecture`; if not
+    set, fall back to legacy `cfg["architectures"][0]`.
+- [ ] Create example dir `res/multi_example/` with:
+  - top-level `nntr_config.json`
+  - `linear_model/{config.json, generation_config.json}`
+  - `qwen3-0.6b/{config.json, generation_config.json}` (mirroring existing
+    qwen3-4b configs scaled to 0.6B: hidden_size=1024, num_hidden_layers=28,
+    num_attention_heads=16, num_key_value_heads=8, intermediate_size=3072,
+    vocab_size=151936, head_dim=128, etc. — matching HF
+    `Qwen/Qwen3-0.6B`).
+- [ ] `meson compile -C build` (or existing build dir) and iterate until
+      clean.
+- [ ] Commit to `claude/multi-model-config-vrXd1` and push.
+
+## Non-goals (out of scope for this PR)
+- Actual multi-model tensor plumbing (e.g., feeding one model's output
+  embeddings into another). Will be a follow-up once the config scaffolding
+  lands.
+- Vision encoder implementation.
+- Re-running existing single-model configs to add `architectures` to
+  nntr_config.json — legacy path stays, we just don't *require* config.json
+  to have `architectures` anymore when using the new multi-model flow.
+
+## Review
+(To be filled in after implementation.)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,11 +1,17 @@
 # Multi-Model nntr_config Support
 
 ## Goal
-Extend Applications/CausalLM so that a single top-level `nntr_config.json`
-can describe multiple sub-models (e.g. vision-encoder + LLM, or Linear +
-Qwen3-0.6B). Move `architectures` out of HF `config.json` into the per-model
-entry of `nntr_config.json`. Each sub-model lives in its own directory with
-its own `config.json` / `generation_config.json` / weight file.
+Let a single top-level `nntr_config.json` describe multiple sub-models, so
+that already-registered architectures (e.g. `Qwen3ForCausalLM`,
+`LlamaForCausalLM`, `Gemma3ForCausalLM`, ...) can be composed just via
+configuration — no new model classes needed.
+
+Move `architecture` selection out of HF `config.json` and into
+`nntr_config.json`. Each sub-model lives in its own sub-directory with its
+own `config.json` / `generation_config.json` / weight file.
+
+Example demo: **two `Qwen3-0.6B` instances stacked** described by one
+top-level `nntr_config.json`.
 
 ## Design
 
@@ -26,16 +32,16 @@ its own `config.json` / `generation_config.json` / weight file.
 
     "models": [
         {
-            "name":  "prelinear",
-            "architecture": "LinearCausalLM",
-            "dir":   "linear_model",
-            "model_file_name": "nntr_linear.bin",
+            "name":  "qwen3_a",
+            "architecture": "Qwen3ForCausalLM",
+            "dir":   "qwen3-0.6b",
+            "model_file_name": "nntr_qwen3_0.6b_fp32.bin",
             "model_type": "CausalLM",
             "fc_layer_dtype": "FP32",
             "embedding_dtype": "FP32"
         },
         {
-            "name":  "qwen3",
+            "name":  "qwen3_b",
             "architecture": "Qwen3ForCausalLM",
             "dir":   "qwen3-0.6b",
             "model_file_name": "nntr_qwen3_0.6b_fp32.bin",
@@ -47,83 +53,81 @@ its own `config.json` / `generation_config.json` / weight file.
 }
 ```
 
-### Per-sub-model directory layout
+Notes:
+- `architecture` replaces `config.json["architectures"][0]` — it becomes
+  the Factory key.
+- `dir` is relative to the top-level model_path. Two entries can point to
+  the same dir (as above) when you want the same weights instantiated twice.
+- Per-entry `model_type`, `fc_layer_dtype`, `embedding_dtype`,
+  `model_file_name` are merged into a synthesized `nntr_sub_cfg` that is
+  handed to `Transformer::setupParameters(...)` unchanged.
+
+### Directory layout
 
 ```
 res/multi_example/
 ├── nntr_config.json            # top-level (above)
-├── linear_model/
-│   ├── config.json             # HF-ish, no "architectures" field
-│   └── generation_config.json
 └── qwen3-0.6b/
-    ├── config.json             # standard HF Qwen3 config w/o architectures
+    ├── config.json             # HF-style, "architectures" field optional
     └── generation_config.json
 ```
 
-Weight file locations follow `model_file_name` relative to the sub-model dir.
-
 ### Config-loading rules
-- `architecture` comes from the sub-model entry in `nntr_config.json`.
-- Per-sub-model `config.json` provides HF dims; `architectures` field (if
-  still present) is ignored.
-- Top-level nntr keys (tokenizer_file, batch_size, max_seq_len, fsu, ...) are
-  shared; per-sub-model keys override them.
-- Each sub-model sees a *synthesized* `nntr_cfg` = top-level keys merged
-  with its own entry fields, so existing `setupParameters(...)` code works
-  unchanged.
+- `architecture` is taken from the per-entry value. HF `config.json`'s
+  `architectures` field is ignored when the new multi-model flow is used.
+- Top-level nntr keys (tokenizer_file, batch_size, max_seq_len, fsu, ...)
+  are shared; per-entry keys override them.
+- Each sub-model gets a `nntr_sub_cfg = deep_copy(top_level) U entry`, so
+  existing `Transformer::setupParameters`, `CausalLM::setupParameters`, etc.
+  keep working without modification.
 
-### Orchestration
-For this PR we only wire up *independent load/initialize* for N models.
-Actual pipelining (vision→LLM, logit fusion, etc.) is future work. The
-binary runs the **last** model in `models` against `sample_input` so the
-existing single-model run path is preserved; earlier models are just loaded
-and initialized (demonstrates that multiple models co-exist).
+### Orchestration (this PR)
+Scope = *loading* multiple models from one config. For the demo the binary:
+1. Reads top-level nntr_config.json.
+2. For each entry in `models`: loads that sub-dir's config.json &
+   generation_config.json, creates the model via Factory, initializes, and
+   loads weights.
+3. Runs each model once with the shared `sample_input` (sequential runs, no
+   tensor plumbing between them yet).
+
+Actual stacking (feeding one model's hidden state / tokens into the next)
+is follow-up work and out of scope — the point of this PR is the config
+scaffolding.
 
 ### Backward compatibility
-`main.cpp` detects multi-model mode by presence of `"models"` array in
-`nntr_config.json`. Otherwise it falls through to the current single-model
-path unchanged.
+Detect multi-model mode by presence of `"models"` array in
+`nntr_config.json`. Otherwise fall through to the current single-model
+code path unchanged.
 
 ## Tasks
 
-- [ ] Implement `LinearCausalLM` at `models/linear/linear_causallm.{h,cpp}`
-      — a `CausalLM` subclass whose `constructModel()` is just
-      `input → embedding → fully_connected → lm_head` (no transformer
-      blocks, no RoPE/attention). Override `setupParameters` to tolerate
-      missing transformer-specific fields.
-- [ ] Add `subdir('linear')` to `Applications/CausalLM/models/meson.build`
-      and a `linear/meson.build` mirroring `qwen3/meson.build`.
-- [ ] Register `"LinearCausalLM"` factory entry in `main.cpp`.
-- [ ] Refactor `main.cpp`:
-  - Detect `nntr_cfg["models"]`.
-  - For each entry: build per-model `nntr_sub_cfg` by deep-copying top-level
-    and overlaying entry fields; load `<model_path>/<dir>/config.json` and
-    `<model_path>/<dir>/generation_config.json`; call
-    `Factory::create(architecture, cfg, gen, nntr_sub_cfg)`; `initialize()`;
-    `load_weight(<model_path>/<dir>/<model_file_name>)`.
-  - Keep the current legacy path when `"models"` is absent.
-  - Change architecture resolution: prefer per-entry `architecture`; if not
-    set, fall back to legacy `cfg["architectures"][0]`.
-- [ ] Create example dir `res/multi_example/` with:
-  - top-level `nntr_config.json`
-  - `linear_model/{config.json, generation_config.json}`
-  - `qwen3-0.6b/{config.json, generation_config.json}` (mirroring existing
-    qwen3-4b configs scaled to 0.6B: hidden_size=1024, num_hidden_layers=28,
-    num_attention_heads=16, num_key_value_heads=8, intermediate_size=3072,
-    vocab_size=151936, head_dim=128, etc. — matching HF
-    `Qwen/Qwen3-0.6B`).
-- [ ] `meson compile -C build` (or existing build dir) and iterate until
-      clean.
+- [ ] Refactor `Applications/CausalLM/main.cpp`:
+  - After loading `nntr_cfg`, check for `"models"`.
+  - If absent → current legacy path, unchanged.
+  - If present → for each entry build `nntr_sub_cfg`, load
+    `<model_path>/<dir>/config.json` and
+    `<model_path>/<dir>/generation_config.json`, resolve `architecture`
+    from the entry, `Factory::create(...)`, `initialize()`, `load_weight()`.
+    Store in `std::vector<std::unique_ptr<Transformer>>`.
+  - After all loaded, run each model once with `sample_input`.
+- [ ] Create example dir `Applications/CausalLM/res/multi_example/`:
+  - top-level `nntr_config.json` with two Qwen3-0.6B entries.
+  - `qwen3-0.6b/config.json` with real HF Qwen3-0.6B dims (hidden_size=1024,
+    num_hidden_layers=28, num_attention_heads=16, num_key_value_heads=8,
+    head_dim=128, intermediate_size=3072, vocab_size=151936,
+    max_position_embeddings=40960, rope_theta=1000000,
+    tie_word_embeddings=true, rms_norm_eps=1e-6).
+  - `qwen3-0.6b/generation_config.json` (eos/bos/temperature/top_k/top_p).
+- [ ] `meson compile -C build` iterate until clean.
 - [ ] Commit to `claude/multi-model-config-vrXd1` and push.
 
-## Non-goals (out of scope for this PR)
-- Actual multi-model tensor plumbing (e.g., feeding one model's output
-  embeddings into another). Will be a follow-up once the config scaffolding
-  lands.
-- Vision encoder implementation.
-- Re-running existing single-model configs to add `architectures` to
-  nntr_config.json — legacy path stays, we just don't *require* config.json
-  to have `architectures` anymore when using the new multi-model flow.
+## Non-goals
+- Actual tensor pipelining between sub-models.
+- Creating new model classes (LinearCausalLM etc.) — user already has the
+  architectures they want.
+- Touching `quantize.cpp` / `api/causal_lm_api.cpp` — their single-model
+  flow is unchanged.
+- Providing weight `.bin` files for Qwen3-0.6B; user converts on their own.
 
 ## Review
 (To be filled in after implementation.)


### PR DESCRIPTION
Draft the design for letting a single nntr_config.json describe multiple
sub-models (e.g. LinearCausalLM + Qwen3-0.6B) with per-model sub-directories
each containing their own config.json.

https://claude.ai/code/session_01BWPSjJWXeKebeziU9vkTKH