### PR TITLE
tensor-api: bind input Tensor handles to graph placeholders at compile end

### DIFF
--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -32,7 +32,8 @@
 
 namespace nntrainer {
 class RunLayerContext;
-}
+class Tensor;
+} // namespace nntrainer
 /** Define more aliases for the model in the API */
 namespace ml {
 namespace train {
@@ -324,6 +325,20 @@ public:
                                   void * /**< user_data */)>
                  fn,
                void *user_data = nullptr) = 0;
+
+  /**
+   * @brief Look up a graph-managed tensor by name.
+   *
+   * Used by the symbolic ml::train::Tensor API to wire a user-facing
+   * Tensor handle to its corresponding graph placeholder after compile.
+   * Once wired, host-side updates flow through `tensor.setData(buf)` instead
+   * of going through a separate setExternalTensors call by name.
+   *
+   * @param name tensor or input-layer name
+   * @return Tensor* pointer to the graph-owned tensor, or nullptr if no
+   *         such tensor exists in the compiled graph.
+   */
+  virtual nntrainer::Tensor *getTensor(const std::string &name) = 0;
 
   /**
    * @brief     set optimizer for the neural network model

--- a/api/ccapi/src/tensor_api.cpp
+++ b/api/ccapi/src/tensor_api.cpp
@@ -174,15 +174,37 @@ void Tensor::copyFrom(const void *src) {
 }
 
 void Tensor::setData(void *new_ptr) {
-  if (!impl_ || !impl_->external) {
-    throw std::runtime_error("setData: only supported for fromData tensors");
+  if (!impl_) {
+    throw std::runtime_error("setData: tensor is not materialized");
   }
   if (!new_ptr) {
     throw std::invalid_argument("setData: pointer must not be null");
   }
-  impl_->external_ptr = new_ptr;
-  impl_->eager_data->setData(std::make_shared<nntrainer::MemoryData>(new_ptr),
-                             0, false);
+
+  // Bound case: this Tensor is wired to a graph-owned placeholder by
+  // Model::compile(inputs, outputs, mode). Pointing the placeholder's
+  // MemoryData at the host buffer turns subsequent forward()/inference
+  // calls into a zero-copy read of the caller's memory — no separate
+  // setExternalTensors() round trip needed.
+  if (impl_->bound_tensor) {
+    impl_->external_ptr = new_ptr;
+    impl_->bound_tensor->setData(
+      std::make_shared<nntrainer::MemoryData>(new_ptr), 0, false);
+    return;
+  }
+
+  // fromData (eager external) case: same idea but on the user-side
+  // eager_data tensor that was created at fromData() time.
+  if (impl_->external && impl_->eager_data) {
+    impl_->external_ptr = new_ptr;
+    impl_->eager_data->setData(std::make_shared<nntrainer::MemoryData>(new_ptr),
+                               0, false);
+    return;
+  }
+
+  throw std::runtime_error(
+    "setData: tensor is neither bound to a graph placeholder nor a fromData "
+    "external tensor");
 }
 
 // --- Private helpers ---

--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -449,7 +449,16 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
     return status;
   }
 
-  // 6. Materialize API tensors with allocated buffers
+  // 6. Wire each input Tensor handle to the graph-owned placeholder so the
+  //    caller can update data via `inp.setData(host_buf)` instead of going
+  //    through Model::setExternalTensors({inp}, {name}). The placeholder
+  //    name is the input layer name we registered in step 1 (or the name a
+  //    user-supplied input layer was created with).
+  //
+  //    Falls back to creating a fresh eager_data tensor when the lookup
+  //    misses — covers tests that compile a model without going through the
+  //    full input-layer creation path. Production code should always hit the
+  //    bound_tensor branch.
   for (auto &inp : inputs) {
     std::string inp_name = inp.name();
     if (inp_name.empty()) {
@@ -457,10 +466,16 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
                    ? "graph_input"
                    : "graph_input_" + std::to_string(&inp - &inputs[0]);
     }
-    const TensorDim &in_dim = inp.shape();
-    inp.impl_->eager_data = std::make_shared<nntrainer::Tensor>(
-      in_dim, true, nntrainer::Initializer::ZEROS, inp_name);
-    inp.impl_->eager_data->initialize();
+    nntrainer::Tensor *placeholder = getTensor(inp_name);
+    if (placeholder != nullptr) {
+      inp.impl_->bound_tensor = placeholder;
+      inp.impl_->dim = placeholder->getDim();
+    } else {
+      const TensorDim &in_dim = inp.shape();
+      inp.impl_->eager_data = std::make_shared<nntrainer::Tensor>(
+        in_dim, true, nntrainer::Initializer::ZEROS, inp_name);
+      inp.impl_->eager_data->initialize();
+    }
   }
   for (auto &output : outputs) {
     auto output_producer = output.getProducingLayer();

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -549,6 +549,33 @@ public:
     tensor_manager->setWeightOffset(offsets);
   }
 
+  /**
+   * @brief Look up a graph tensor by name.
+   *
+   * Used by the ml::train::Tensor symbolic API to wire each input Tensor
+   * handle to its corresponding graph placeholder right after
+   * compile/initialize/allocate, so post-compile updates can flow through
+   * `tensor.setData(host_buf)` instead of an external by-name binding.
+   *
+   * Returns nullptr (rather than throwing) when the name is missing. Manager
+   * itself throws std::out_of_range from the underlying unordered_map::at;
+   * the binding loop in tensor_api_graph wants a yes/no answer to decide
+   * between bound_tensor and a fallback eager_data tensor, so the throw
+   * gets absorbed here.
+   *
+   * @param name tensor or input-layer name
+   * @return Tensor* pointer to the graph-owned tensor; nullptr if not found.
+   */
+  Tensor *getTensor(const std::string &name) {
+    if (!tensor_manager)
+      return nullptr;
+    try {
+      return tensor_manager->getTensor(name);
+    } catch (...) {
+      return nullptr;
+    }
+  }
+
 private:
   std::map<std::string, std::string> sub_in_out; /** This is map to identify
                  input and output layer name of subgraph */

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -458,6 +458,13 @@ public:
     void *user_data = nullptr) override;
 
   /**
+   * @copydoc ml::train::Model::getTensor(const std::string &)
+   */
+  Tensor *getTensor(const std::string &name) override {
+    return model_graph.getTensor(name);
+  }
+
+  /**
    * @brief     Run NeuralNetwork train with callback function by user
    * @param[in] dt datatype (mode) where it should be
    * @param[in] databuffer set the databuffer


### PR DESCRIPTION
## Summary

Wires `ml::train::Tensor` handles to their corresponding graph-owned placeholders at the end of `Model::compile(inputs, outputs, mode)`. With the binding in place, host-side data updates flow through `tensor.setData(host_buf)` directly - no separate `setExternalTensors(host_tensors, names)` round trip.

The `Impl::bound_tensor` field already existed and was honoured by 15 read sites (`getValue`, `data<T>()`, `mutable_data<T>()`, `copyFrom`, etc.). Only the binding step itself was missing - this PR fills it in.

## Why

`setExternalTensors(host_tensors, names)` is a transitional API. With the symbolic Tensor API:
- The user creates Tensor handles for inputs (`Tensor cache_k(dim)`, `Tensor position(...)`)
- Passes them into `LayerHandle()` calls to build the graph
- Calls `model->compile({tokens, cache_k, cache_v, position}, {logits}, mode)`

At this point, the user's Tensor handles already represent the inputs the graph needs. The binding from "user's Tensor" to "compiled graph's placeholder tensor" is implicit in the `inputs` argument. The old `setExternalTensors` API does the same binding by name - duplicate work the symbolic API can absorb.

## Changes

### `api/ccapi/src/tensor_api_graph.cpp::Model::compile`

Replaces the post-compile loop that created a fresh `eager_data` tensor for each input with a `getTensor(name)` lookup against the compiled graph. On hit, sets `bound_tensor`. On miss, falls through to the old `eager_data` path so tests that compile without going through input-layer creation still work.

### `api/ccapi/src/tensor_api.cpp::Tensor::setData`

Adds the write-through branch: if `bound_tensor` is set, swap its `MemoryData` to the new host pointer. The fromData/`external` branch stays for use before compile.

### `api/ccapi/include/model.h` + `nntrainer/models/neuralnet.h` + `nntrainer/graph/network_graph.h`

Adds `Model::getTensor(name)` virtual + `NeuralNetwork` override that delegates to `NetworkGraph::getTensor` → `Manager::getTensor`. The wrapper absorbs `std::out_of_range` that Manager throws on a name miss so the binding loop sees a yes/no answer instead of an exception. Also adds a forward declaration for `nntrainer::Tensor` in `model.h`.

## Test plan

- [x] `ninja -C build` - 237/237, exit 0
- [x] `clang-format-14 --dry-run --Werror` - clean
- [x] `nntrainer_ccapi_graph` (12 tests) - PASSED, including
  - `data_injection_after_compile_p`
  - `set_get_value_bound_p`
  - `multi_layer_bind_p`
  - `multiple_leaf_inputs_p`
  - `picogpt_style_transformer_p`
  - `picogpt_style_inference_p`
  - `causallm_style_multi_input_p`
- [x] `nntrainer_ccapi_tensor` (86 tests) - PASSED
- [x] `unittest_compute_ops_dispatch` (10 tests) - PASSED
- [x] `unittest_nntrainer_tensor_pool` (48 tests) - PASSED

## Stats

5 files changed, +97 / -11.

## Stacked on

PR #5 (`feature/causallm-tensor-api`).

## Effects on stacked PRs (#6-#8 + B4)

This change unblocks removing `Model::setExternalTensors` calls from PR-B2 (mha-external-cache) and PR-B3 (forwarding-unified). Those PRs will follow up with `setData(buf)` migration in their cache_K / cache_V / position binding paths, plus `Model::setExternalTensors` itself can be deprecated and eventually removed.

https://claude.ai/code/session_0157UmMJrMV4SVRvzr9ugmrT

---
_Generated by [Claude Code](https://claude.ai/code/session_0157UmMJrMV4SVRvzr9ugmrT)_