### PR TITLE
InputLayer: per-input tensor_dtype + propagate from symbolic Tensor

### DIFF
--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -28,6 +28,45 @@
 namespace ml {
 namespace train {
 
+namespace {
+
+/**
+ * @brief Map a TensorDim::DataType to the string token InputLayer's
+ *        `tensor_dtype` property accepts. Returns "" for FP32 (the default,
+ *        in which case the property need not be set) and for types that
+ *        cannot be expressed as a typed input (NONE / quantized variants
+ *        without a string token).
+ */
+std::string dtypeToString(TensorDim::DataType d) {
+  using DT = TensorDim::DataType;
+  switch (d) {
+  case DT::FP32:
+    return ""; // default, no need to override
+  case DT::FP16:
+    return "FP16";
+  case DT::UINT8:
+    return "UINT8";
+  case DT::UINT16:
+    return "UINT16";
+  case DT::UINT32:
+    return "UINT32";
+  case DT::QINT8:
+    return "QINT8";
+  case DT::QINT16:
+    return "QINT16";
+  case DT::Q4_K:
+    return "Q4_K";
+  case DT::Q6_K:
+    return "Q6_K";
+  case DT::Q4_0:
+    return "Q4_0";
+  default:
+    return ""; // BCQ, QINT4, UINT4, NONE — fall back to default
+  }
+}
+
+} // namespace
+
 std::shared_ptr<Layer> Tensor::getProducingLayer() const {
   return (impl_ && impl_->graph_edge) ? impl_->graph_edge->producing_layer
                                       : nullptr;
@@ -393,8 +432,18 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
     std::string shape_str = std::to_string(dim.channel()) + ":" +
                             std::to_string(dim.height()) + ":" +
                             std::to_string(dim.width());
-    auto input_layer =
-      createLayer("input", {"name=" + inp_name, "input_shape=" + shape_str});
+    std::vector<std::string> input_props = {"name=" + inp_name,
+                                            "input_shape=" + shape_str};
+    // Honour the symbolic Tensor's dtype: if the placeholder was declared
+    // with a non-default DataType (e.g. FP16 for KV cache, UINT16 for
+    // quantized inputs), forward it as `tensor_dtype=...` so InputLayer's
+    // finalize() doesn't coerce it to the model's activation dtype.
+    {
+      std::string s = dtypeToString(dim.getDataType());
+      if (!s.empty())
+        input_props.push_back("tensor_dtype=" + s);
+    }
+    auto input_layer = createLayer("input", input_props);
     status = addLayer(std::move(input_layer));
     if (status != ML_ERROR_NONE) {
       return status;
@@ -406,8 +455,14 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
     std::string leaf_shape = std::to_string(leaf_info.dim.channel()) + ":" +
                              std::to_string(leaf_info.dim.height()) + ":" +
                              std::to_string(leaf_info.dim.width());
-    auto leaf_layer =
-      createLayer("input", {"name=" + leaf_name, "input_shape=" + leaf_shape});
+    std::vector<std::string> leaf_props = {"name=" + leaf_name,
+                                           "input_shape=" + leaf_shape};
+    {
+      std::string s = dtypeToString(leaf_info.dim.getDataType());
+      if (!s.empty())
+        leaf_props.push_back("tensor_dtype=" + s);
+    }
+    auto leaf_layer = createLayer("input", leaf_props);
     status = addLayer(std::move(leaf_layer));
     if (status != ML_ERROR_NONE) {
       return status;

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -33,7 +33,43 @@ namespace nntrainer {
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 InputLayer::InputLayer() :
-  Layer(), input_props(props::Normalization(), props::Standardization()) {}
+  Layer(),
+  input_props(props::Normalization(), props::Standardization(),
+              props::TensorDtype()) {}
+
+namespace {
+
+/**
+ * @brief Parse a tensor_dtype property value into a DataType enum, falling
+ *        back to FP32 (only used when the string is non-empty).
+ */
+ml::train::TensorDim::DataType parse_dtype(const std::string &s) {
+  using DT = ml::train::TensorDim::DataType;
+  if (s == "FP32" || s == "fp32")
+    return DT::FP32;
+  if (s == "FP16" || s == "fp16")
+    return DT::FP16;
+  if (s == "UINT8" || s == "uint8")
+    return DT::UINT8;
+  if (s == "UINT16" || s == "uint16")
+    return DT::UINT16;
+  if (s == "UINT32" || s == "uint32")
+    return DT::UINT32;
+  if (s == "QINT8" || s == "qint8")
+    return DT::QINT8;
+  if (s == "QINT16" || s == "qint16")
+    return DT::QINT16;
+  if (s == "Q4_K" || s == "q4_k")
+    return DT::Q4_K;
+  if (s == "Q6_K" || s == "q6_k")
+    return DT::Q6_K;
+  if (s == "Q4_0" || s == "q4_0")
+    return DT::Q4_0;
+  throw std::invalid_argument("InputLayer: unknown tensor_dtype value '" + s +
+                              "'");
+}
+
+} // namespace
 
 void InputLayer::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, input_props);
@@ -72,14 +108,23 @@ void InputLayer::exportTo(Exporter &exporter,
 
 void InputLayer::finalize(InitLayerContext &context) {
 
+  // If the user pinned a per-input dtype with `tensor_dtype=...`, honour that
+  // (typed inputs — KV caches, INT-coded tokens, etc.). Otherwise fall back
+  // to the model's global activation dtype, matching legacy behaviour.
+  const auto &dtype_prop = std::get<props::TensorDtype>(input_props);
+  const bool has_explicit_dtype = !dtype_prop.empty();
+  const ml::train::TensorDim::DataType output_dtype =
+    has_explicit_dtype ? parse_dtype(dtype_prop.get())
+                       : context.getActivationDataType();
+
   std::vector<TensorDim> output_dims = context.getInputDimensions();
   for (auto &d : output_dims) {
-    d.setDataType(context.getActivationDataType());
+    d.setDataType(output_dtype);
   }
 
   context.setOutputDimensions(output_dims);
   is_inplace = true;
-  if (context.getActivationDataType() != ml::train::TensorDim::DataType::FP32)
+  if (output_dtype != ml::train::TensorDim::DataType::FP32)
     is_inplace = false;
 }
 

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -29,6 +29,39 @@
 
 namespace nntrainer {
 
+namespace props {
+
+/**
+ * @brief Per-input-layer override of the output tensor data type.
+ *
+ * Without this, InputLayer::finalize() coerces the output dtype to the
+ * model's global activation dtype (set via "model_tensor_type"), which makes
+ * it impossible for, e.g., an FP16 KV-cache or INT-coded tokens placeholder
+ * to coexist with FP32 activations.
+ *
+ * Accepted values: "FP32", "FP16", "UINT8", "UINT16", "UINT32", "QINT8" ...
+ *                  (anything ml::train::TensorDim::DataType supports as a
+ *                  string token via str_converter).
+ *
+ * Mainly used by the symbolic Tensor → input layer auto-creation path in
+ * tensor_api so a Tensor declared with FP16 dim wires up a matching FP16
+ * input layer at compile time.
+ */
+class TensorDtype final : public nntrainer::Property<std::string> {
+public:
+  /**
+   * @brief Default-constructed TensorDtype is an UNSET property
+   *        (`empty() == true`). Use the explicit-value constructor — or set
+   *        via `setProperty({"tensor_dtype=FP16"})` — to pin the dtype.
+   */
+  TensorDtype() = default;
+  explicit TensorDtype(const std::string &value) { set(value); }
+  static constexpr const char *key = "tensor_dtype";
+  using prop_tag = nntrainer::str_prop_tag;
+};
+
+} // namespace props
+
 /**
  * @class   Input Layer
  * @note    input layers requires to be only single input, consider making the
@@ -112,7 +145,8 @@ public:
   static constexpr const char *type = "input";
 
 private:
-  std::tuple<props::Normalization, props::Standardization> input_props;
+  std::tuple<props::Normalization, props::Standardization, props::TensorDtype>
+    input_props;
 };
 } // namespace nntrainer
 

--- a/test/ccapi/unittest_ccapi_tensor.cpp
+++ b/test/ccapi/unittest_ccapi_tensor.cpp
@@ -1484,3 +1484,58 @@ TEST(nntrainer_ccapi_graph, causallm_style_multi_input_p) {
   EXPECT_FALSE(output_bufs.empty());
   EXPECT_NE(output_bufs[0], nullptr);
 }
+
+// ===== PR-B4: Typed input layer (tensor_dtype) =====
+
+/**
+ * @brief A symbolic input Tensor declared with a non-FP32 dim must compile
+ *        into an InputLayer that preserves that dtype (via the new
+ *        tensor_dtype property), instead of being silently coerced to the
+ *        model's activation dtype. This is what lets typed KV caches —
+ *        FP16/UINT16 — coexist with FP32 activations in the same graph.
+ */
+#ifdef ENABLE_FP16
+TEST(nntrainer_ccapi_graph, typed_input_fp16_compile_p) {
+  using namespace ml::train;
+  TensorDim fp16_dim(
+    {1, 1, 1, 4},
+    TensorDim::TensorType(TensorDim::Format::NCHW, TensorDim::DataType::FP16));
+  auto x = Tensor(fp16_dim, "fp16_input");
+  LayerHandle id = createLayer("identity", {"name=id_layer"});
+  Tensor y = id(x);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y, ExecutionMode::INFERENCE), ML_ERROR_NONE);
+}
+#endif
+
+/**
+ * @brief Same shape check, but UINT16 — exercises the "InputLayer dtype !=
+ *        activation dtype" fallback path (is_inplace becomes false, etc.).
+ */
+TEST(nntrainer_ccapi_graph, typed_input_uint16_compile_p) {
+  using namespace ml::train;
+  TensorDim u16_dim({1, 1, 1, 4},
+                    TensorDim::TensorType(TensorDim::Format::NCHW,
+                                          TensorDim::DataType::UINT16));
+  auto x = Tensor(u16_dim, "uint16_input");
+  LayerHandle id = createLayer("identity", {"name=id_layer"});
+  Tensor y = id(x);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y, ExecutionMode::INFERENCE), ML_ERROR_NONE);
+}
+
+/**
+ * @brief FP32 dim — control test. Compile must succeed without emitting
+ *        tensor_dtype (default behaviour unchanged).
+ */
+TEST(nntrainer_ccapi_graph, typed_input_fp32_default_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 4}, "fp32_input"); // default = FP32
+  LayerHandle fc = createLayer("fully_connected", {"unit=4", "name=fc"});
+  Tensor y = fc(x);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y, ExecutionMode::INFERENCE), ML_ERROR_NONE);
+}


### PR DESCRIPTION
## Summary

Fix the long-standing coercion in `InputLayer::finalize()` that silently overwrites the input's declared dtype with the model's global activation dtype. Without this, a symbolic Tensor declared:

```cpp
Tensor({1,1,max_seq,kv_w}, "cache_k_l0")   // FP16 dim
```

with FP16 dim still ends up as an FP32 input layer at compile time, which breaks any typed binding (KV cache, INT-coded tokens, etc.) made through `Model::setExternalTensors`. Surfaced while wiring the FP16 KV cache + FP32 position placeholders in PR #7 / PR #8.

## Changes

### Framework

- **`nntrainer/layers/input_layer.h`** — new property:
  ```
  nntrainer::props::TensorDtype : Property<std::string>
                                  key = "tensor_dtype"
  ```
  String values matching `ml::train::TensorDim::DataType` tokens (FP32, FP16, UINT8, UINT16, UINT32, QINT8, QINT16, Q4_K, Q6_K, Q4_0). Default-constructed = unset → InputLayer falls back to the model's activation dtype (legacy behaviour, no change for existing callers).
- **`nntrainer/layers/input_layer.cpp`**:
  - `parse_dtype()` helper for the string → enum mapping.
  - `finalize()` now consults `TensorDtype` first; only falls back to `context.getActivationDataType()` when the property is unset.
  - `is_inplace` flag is computed from the resolved output dtype, not the activation dtype, so an FP16 input on an FP32 model correctly drops out of the in-place fast path.

### Symbolic graph

- **`api/ccapi/src/tensor_api_graph.cpp`** — when the Tensor → `Model::compile` walk auto-creates an `"input"` layer for an explicit input or an unproduced leaf Tensor, it now reads the symbolic dim's `DataType` and, if non-FP32, forwards it as `tensor_dtype=...` on the new input layer. `dtypeToString()` handles the enum → property-token mapping (returning `""` for FP32 and types that have no string token, so the default path is unchanged).

### Tests

- **`test/ccapi/unittest_ccapi_tensor.cpp`** — three new tests under `nntrainer_ccapi_graph`:
  - `typed_input_uint16_compile_p` — UINT16 input compiles cleanly
  - `typed_input_fp32_default_p` — FP32 baseline still compiles (no `tensor_dtype` emitted)
  - `typed_input_fp16_compile_p` — FP16 input compiles (gated on `ENABLE_FP16`)

## Test plan

- [x] `ninja -C build` — 547/547, exit 0
- [x] `clang-format-14 --dry-run --Werror` — clean
- [x] `unittest_ccapi --gtest_filter='nntrainer_ccapi_graph.typed_input_*'` — 2/2 PASSED (FP16 test compiled-out, this build has `enable-fp16=false`)
- [x] `unittest_kv_cache_manager` — 20/20 PASSED (no regression)

## Stats

4 files changed, +197 / -8.

## Stacked on

PR #8 (`feature/forwarding-unified`).

https://claude.ai/code/session_0157UmMJrMV4SVRvzr9ugmrT

---
_Generated by [Claude Code](https://claude.ai/code/session_0157UmMJrMV4SVRvzr9ugmrT)_